### PR TITLE
Add failing unit test for waitForXPath bug

### DIFF
--- a/test/waittask.spec.ts
+++ b/test/waittask.spec.ts
@@ -680,6 +680,25 @@ describe('waittask specs', function () {
         )
       ).toBe('hello  world  ');
     });
+    it.only('should wait when text content within a node is modified to match the xpath', async () => {
+      const { page } = getTestState();
+      let error;
+      await page.setContent(`<div></div>`);
+      const waitForXPath = page.waitForXPath(
+        '//p[contains(.,"Three")]',
+      ).then(() => true).catch((errorMessage) => error = errorMessage);
+      await page.evaluate(() => {
+        const paragraphElement = document.createElement('p');
+        document.querySelector('div').appendChild(paragraphElement);
+        paragraphElement.innerText = 'One';
+        paragraphElement.firstChild.nodeValue = 'Two';
+        setTimeout(() => {
+          paragraphElement.firstChild.nodeValue = 'Three';
+        }, 1000);
+      });
+      expect(await waitForXPath).toBe(true);
+      expect(error).toBeFalsy();
+    });
     it('should respect timeout', async () => {
       const { page, puppeteer } = getTestState();
 


### PR DESCRIPTION
Puppeteer's `waitForXPath` function utility doesn't wait for an element if that's text content is modified using `element.firstChild.nodeValue = 'some text'`.

The react-dom library primarily mutates `nodeValue` if a node already has text so this is a very popular way to update text content on the web - https://github.com/facebook/react/blob/9198a5cec0936a21a5ba194a22fcbac03eba5d1d/packages/react-dom/src/client/setTextContent.js.

Here's a text example of how the issue happens:
1. A web page has an element `<div>one</div>`
2. A test is using `await page.waitForXPath( '//div[.="two"]' );` to wait for a modification to this element
3. The web page is modified using `element.firstChild.nodeValue = 'two'` to update the text content.
4. The test will time out.

The underlying problem is that `waitForXPath` uses a `MutationObserver` to listen for changes with the `childList` and `subtree` options. Modifying `nodeValue` doesn't seem to trigger the `MutationObserver`.